### PR TITLE
Fixing all warnings and non-checked errors

### DIFF
--- a/pkg/meroxa/api_errors.go
+++ b/pkg/meroxa/api_errors.go
@@ -2,7 +2,6 @@ package meroxa
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -65,7 +64,7 @@ func parseErrorFromBody(resp *http.Response) (error, error) {
 	if err != nil {
 		// In cases we didn't receive a proper JSON response
 		if _, ok := err.(*json.SyntaxError); ok {
-			return nil, errors.New(fmt.Sprintf("%s %s", resp.Proto, resp.Status))
+			return nil, fmt.Errorf("%s %s", resp.Proto, resp.Status)
 		}
 
 		return nil, err

--- a/pkg/meroxa/api_errors_test.go
+++ b/pkg/meroxa/api_errors_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"reflect"
 	"testing"
 )
 
@@ -21,14 +20,6 @@ func errorJSONResponse(msg string) io.ReadCloser {
 
 // create a new reader with an HTML response
 var errorHTMLResponse = ioutil.NopCloser(bytes.NewReader([]byte(`<h1>Error!</h1>`)))
-
-var http503JSONResponse = &http.Response{
-	StatusCode: 503,
-	Status:     "503 Service Unavailable",
-	Body:       errorJSONResponse(`{ "error": "api error" }`),
-	Proto:      "HTTP/1.0",
-	Header:     make(http.Header),
-}
 
 var http422JSONResponse = func(body io.ReadCloser) *http.Response {
 	return &http.Response{
@@ -90,7 +81,7 @@ func TestHandleAPIErrors(t *testing.T) {
 	for _, tt := range tests {
 		err := handleAPIErrors(tt.in)
 
-		if !reflect.DeepEqual(err, tt.err) {
+		if err != nil && (err.Error() != tt.err.Error()) {
 			t.Errorf("expected %+v, got %+v", tt.err, err)
 		}
 

--- a/pkg/meroxa/application_test.go
+++ b/pkg/meroxa/application_test.go
@@ -41,7 +41,9 @@ func TestCreateApplication(t *testing.T) {
 
 		// Return response to satisfy client and test response
 		c := generateApplication(input.Name)
-		json.NewEncoder(w).Encode(c)
+		if err := json.NewEncoder(w).Encode(c); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	// Close the server when test finishes
 	defer server.Close()
@@ -79,7 +81,9 @@ func TestGetApplicationByName(t *testing.T) {
 		defer req.Body.Close()
 
 		// Return response to satisfy client and test response
-		json.NewEncoder(w).Encode(app)
+		if err := json.NewEncoder(w).Encode(app); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	// Close the server when test finishes
 	defer server.Close()
@@ -135,7 +139,9 @@ func TestGetApplicationByUUID(t *testing.T) {
 		defer req.Body.Close()
 
 		// Return response to satisfy client and test response
-		json.NewEncoder(w).Encode(app)
+		if err := json.NewEncoder(w).Encode(app); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	// Close the server when test finishes
 	defer server.Close()
@@ -158,14 +164,16 @@ func TestListApplications(t *testing.T) {
 	list := []*Application{&a1, &a2}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if want, got := fmt.Sprintf("%s", applicationsBasePath), req.URL.Path; want != got {
+		if want, got := applicationsBasePath, req.URL.Path; want != got {
 			t.Fatalf("mismatched of request path: want=%s got=%s", want, got)
 		}
 
 		defer req.Body.Close()
 
 		// Return response to satisfy client and test response
-		json.NewEncoder(w).Encode(list)
+		if err := json.NewEncoder(w).Encode(list); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	// Close the server when test finishes
 	defer server.Close()
@@ -192,7 +200,9 @@ func TestDeleteApplication(t *testing.T) {
 
 		defer req.Body.Close()
 
-		json.NewEncoder(w).Encode(app)
+		if err := json.NewEncoder(w).Encode(app); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -207,7 +217,7 @@ func TestDeleteApplication(t *testing.T) {
 func TestDeleteApplicationEntitiesWithAppNotFound(t *testing.T) {
 	appName := "test"
 	pipelineName := fmt.Sprintf("turbine-pipeline-%s", appName)
-	pipeline := generatePipeline(pipelineName, "", nil)
+	pipeline := generatePipeline(pipelineName, "")
 
 	connectorSrc := generateConnector("src-connector", nil, nil)
 	connectorSrc.PipelineName = pipeline.Name
@@ -226,16 +236,22 @@ func TestDeleteApplicationEntitiesWithAppNotFound(t *testing.T) {
 		if want, got := fmt.Sprintf("name=%s", pipeline.Name), req.URL.RawQuery; want != got {
 			t.Fatalf("mismatched of request query parameter: want=%s got=%s", want, got)
 		}
-		json.NewEncoder(res).Encode(pipeline)
+		if err := json.NewEncoder(res).Encode(pipeline); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 		defer req.Body.Close()
 	})
 	mux.HandleFunc(fmt.Sprintf("%s/%s/connectors", pipelinesBasePath, pipelineName), func(res http.ResponseWriter, req *http.Request) {
 		list := []*Connector{&connectorSrc}
-		json.NewEncoder(res).Encode(list)
+		if err := json.NewEncoder(res).Encode(list); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	})
 	mux.HandleFunc(functionsBasePath, func(res http.ResponseWriter, req *http.Request) {
 		list := []*Function{function}
-		json.NewEncoder(res).Encode(list)
+		if err := json.NewEncoder(res).Encode(list); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	})
 	mux.HandleFunc(fmt.Sprintf("%s/%s", connectorsBasePath, connectorSrc.Name), func(res http.ResponseWriter, req *http.Request) {
 		if req.Method == http.MethodDelete {
@@ -281,7 +297,9 @@ func TestDeleteApplicationEntitiesWithAppFound(t *testing.T) {
 
 		defer req.Body.Close()
 
-		json.NewEncoder(w).Encode(app)
+		if err := json.NewEncoder(w).Encode(app); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	defer server.Close()
 

--- a/pkg/meroxa/auth.go
+++ b/pkg/meroxa/auth.go
@@ -162,6 +162,8 @@ func (ts *tokenSource) retrieveToken(client *http.Client, conf *oauth2.Config, r
 		TokenType:   tokenRes.TokenType,
 	}
 	raw := make(map[string]interface{})
+
+	//nolint:errcheck
 	json.Unmarshal(body, &raw) // no error checks for optional fields
 	token = token.WithExtra(raw)
 

--- a/pkg/meroxa/build_test.go
+++ b/pkg/meroxa/build_test.go
@@ -37,7 +37,9 @@ func TestCreateBuild(t *testing.T) {
 
 		// Return response to satisfy client and test response
 		b := generateBuild("", input.SourceBlob.Url)
-		json.NewEncoder(w).Encode(b)
+		if err := json.NewEncoder(w).Encode(b); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	// Close the server when test finishes
 	defer server.Close()
@@ -67,7 +69,9 @@ func TestGetBuild(t *testing.T) {
 		defer req.Body.Close()
 
 		// Return response to satisfy client and test response
-		json.NewEncoder(w).Encode(build)
+		if err := json.NewEncoder(w).Encode(build); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	// Close the server when test finishes
 	defer server.Close()

--- a/pkg/meroxa/connector_test.go
+++ b/pkg/meroxa/connector_test.go
@@ -66,7 +66,9 @@ func TestCreateConnector(t *testing.T) {
 
 		// Return response to satisfy client and test response
 		c := generateConnector(input.Name, input.Configuration, input.Metadata)
-		json.NewEncoder(w).Encode(c)
+		if err := json.NewEncoder(w).Encode(c); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	// Close the server when test finishes
 	defer server.Close()
@@ -111,7 +113,9 @@ func TestUpdateConnectorStatus(t *testing.T) {
 		// Return response to satisfy client and test response
 		c := generateConnector(connectorKey, nil, nil)
 		c.State = ConnectorState(state)
-		json.NewEncoder(w).Encode(c)
+		if err := json.NewEncoder(w).Encode(c); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	// Close the server when test finishes
 	defer server.Close()
@@ -155,7 +159,9 @@ func TestUpdateConnector(t *testing.T) {
 		}
 
 		// Return response to satisfy client and test response
-		json.NewEncoder(w).Encode(connector)
+		if err := json.NewEncoder(w).Encode(connector); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	// Close the server when test finishes
 	defer server.Close()
@@ -217,7 +223,9 @@ func TestGetConnectorByName(t *testing.T) {
 		defer req.Body.Close()
 
 		// Return response to satisfy client and test response
-		json.NewEncoder(w).Encode(connector)
+		if err := json.NewEncoder(w).Encode(connector); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	// Close the server when test finishes
 	defer server.Close()
@@ -235,7 +243,7 @@ func TestGetConnectorByName(t *testing.T) {
 }
 
 func TestListPipelineConnectors(t *testing.T) {
-	p := generatePipeline("", fmt.Sprint(PipelineStateHealthy), nil)
+	p := generatePipeline("", fmt.Sprint(PipelineStateHealthy))
 	connector := generateConnector("", nil, nil)
 	connector.PipelineName = p.Name
 	list := []*Connector{&connector}
@@ -247,7 +255,9 @@ func TestListPipelineConnectors(t *testing.T) {
 		defer req.Body.Close()
 
 		// Return response to satisfy client and test response
-		json.NewEncoder(w).Encode(list)
+		if err := json.NewEncoder(w).Encode(list); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	// Close the server when test finishes
 	defer server.Close()
@@ -258,7 +268,6 @@ func TestListPipelineConnectors(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error, got %+v", err)
 	}
-
 	if !reflect.DeepEqual(resp, list) {
 		t.Errorf("expected response same as list")
 	}
@@ -270,14 +279,16 @@ func TestListConnectors(t *testing.T) {
 	list := []*Connector{&c1, &c2}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if want, got := fmt.Sprintf("%s", connectorsBasePath), req.URL.Path; want != got {
+		if want, got := connectorsBasePath, req.URL.Path; want != got {
 			t.Fatalf("mismatched of request path: want=%s got=%s", want, got)
 		}
 
 		defer req.Body.Close()
 
 		// Return response to satisfy client and test response
-		json.NewEncoder(w).Encode(list)
+		if err := json.NewEncoder(w).Encode(list); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	// Close the server when test finishes
 	defer server.Close()
@@ -306,23 +317,23 @@ func TestFilterConnectorsPerType(t *testing.T) {
 	connectorsList := []*Connector{&srcConnector1, &srcConnector2, &dstConnector1, &dstConnector2}
 
 	tests := []struct {
-		desc string
-		cType ConnectorType
+		desc         string
+		cType        ConnectorType
 		expectedList []*Connector
 	}{
 		{
-			desc: "Filtering source connectors",
-			cType: ConnectorTypeSource,
+			desc:         "Filtering source connectors",
+			cType:        ConnectorTypeSource,
 			expectedList: []*Connector{&srcConnector1, &srcConnector2},
 		},
 		{
-			desc: "Filtering destination connectors",
-			cType: ConnectorTypeDestination,
+			desc:         "Filtering destination connectors",
+			cType:        ConnectorTypeDestination,
 			expectedList: []*Connector{&dstConnector1, &dstConnector2},
 		},
 		{
-			desc: "Filtering non determined type",
-			cType: ConnectorType("FooType"),
+			desc:         "Filtering non determined type",
+			cType:        ConnectorType("FooType"),
 			expectedList: []*Connector{},
 		},
 	}

--- a/pkg/meroxa/environment.go
+++ b/pkg/meroxa/environment.go
@@ -216,8 +216,7 @@ func (c *client) DeleteEnvironment(ctx context.Context, nameOrUUID string) (*Env
 
 	var e *Environment
 	err = json.NewDecoder(resp.Body).Decode(&e)
-
-	return e, nil
+	return e, err
 }
 
 func (c *client) UpdateEnvironment(ctx context.Context, nameOrUUID string, input *UpdateEnvironmentInput) (*Environment, error) {
@@ -234,8 +233,7 @@ func (c *client) UpdateEnvironment(ctx context.Context, nameOrUUID string, input
 
 	var e *Environment
 	err = json.NewDecoder(resp.Body).Decode(&e)
-
-	return e, nil
+	return e, err
 }
 
 func (c *client) PerformActionOnEnvironment(ctx context.Context, nameOrUUID string, input *RepairEnvironmentInput) (*Environment, error) {
@@ -252,6 +250,5 @@ func (c *client) PerformActionOnEnvironment(ctx context.Context, nameOrUUID stri
 
 	var e *Environment
 	err = json.NewDecoder(resp.Body).Decode(&e)
-
-	return e, nil
+	return e, err
 }

--- a/pkg/meroxa/environment_test.go
+++ b/pkg/meroxa/environment_test.go
@@ -49,7 +49,7 @@ func TestCreateEnvironment(t *testing.T) {
 	environment := &CreateEnvironmentInput{}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if want, got := fmt.Sprintf("%s", environmentsBasePath), req.URL.Path; want != got {
+		if want, got := environmentsBasePath, req.URL.Path; want != got {
 			t.Fatalf("mismatched of request path: want=%s got=%s", want, got)
 		}
 
@@ -81,7 +81,9 @@ func TestCreateEnvironment(t *testing.T) {
 
 		// Return response to satisfy client and test response
 		c := generateEnvironment(environment.Type, environment.Provider, environment.Name, EnvironmentViewStatus{State: "private"})
-		json.NewEncoder(w).Encode(c)
+		if err := json.NewEncoder(w).Encode(c); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	// Close the server when test finishes
 	defer server.Close()
@@ -115,7 +117,7 @@ func TestCreateBadEnvironment(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if want, got := fmt.Sprintf("%s", environmentsBasePath), req.URL.Path; want != got {
+		if want, got := environmentsBasePath, req.URL.Path; want != got {
 			t.Fatalf("mismatched of request path: want=%s got=%s", want, got)
 		}
 
@@ -147,7 +149,9 @@ func TestCreateBadEnvironment(t *testing.T) {
 
 		// Return response to satisfy client and test response
 		c := generateEnvironment(environment.Type, environment.Provider, environment.Name, EnvironmentViewStatus{State: "preflight_error", PreflightDetails: &PreflightDetails{PreflightPermissions: &PreflightPermissions{S3: []string{"missing read permission for S3", "missing write permissions for S3"}}}})
-		json.NewEncoder(w).Encode(c)
+		if err := json.NewEncoder(w).Encode(c); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	// Close the server when test finishes
 	defer server.Close()
@@ -220,7 +224,9 @@ func TestDeleteEnvironment(t *testing.T) {
 		defer req.Body.Close()
 
 		env.Status.State = EnvironmentState(deprovisioningState)
-		json.NewEncoder(w).Encode(env)
+		if err := json.NewEncoder(w).Encode(env); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -252,7 +258,9 @@ func TestUpdateEnvironment(t *testing.T) {
 		defer req.Body.Close()
 
 		env.Name = updatedName
-		json.NewEncoder(w).Encode(env)
+		if err := json.NewEncoder(w).Encode(env); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -290,7 +298,9 @@ func TestRepairEnvironment(t *testing.T) {
 		defer req.Body.Close()
 
 		env.Status.State = "repairing"
-		json.NewEncoder(w).Encode(env)
+		if err := json.NewEncoder(w).Encode(env); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	defer server.Close()
 

--- a/pkg/meroxa/function_test.go
+++ b/pkg/meroxa/function_test.go
@@ -60,7 +60,9 @@ func TestCreateFunction(t *testing.T) {
 			t.Fatalf("mismatch of function input (-want +got): %s", diff)
 		}
 
-		json.NewEncoder(w).Encode(output)
+		if err := json.NewEncoder(w).Encode(output); err != nil {
+			t.Fatalf("expected no error, got %+v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -88,7 +90,9 @@ func TestGetFunction(t *testing.T) {
 			t.Fatalf("mismatched of request path (-want +got): %s", diff)
 		}
 
-		json.NewEncoder(w).Encode(output)
+		if err := json.NewEncoder(w).Encode(output); err != nil {
+			t.Fatalf("expected no error, got %+v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -134,7 +138,9 @@ func TestListFunctions(t *testing.T) {
 			t.Fatalf("mismatched of request path (-want +got): %s", diff)
 		}
 
-		json.NewEncoder(w).Encode(output)
+		if err := json.NewEncoder(w).Encode(output); err != nil {
+			t.Fatalf("expected no error, got %+v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -162,7 +168,9 @@ func TestDeleteFunction(t *testing.T) {
 			t.Fatalf("mismatched of request path (-want +got): %s", diff)
 		}
 
-		json.NewEncoder(w).Encode(output)
+		if err := json.NewEncoder(w).Encode(output); err != nil {
+			t.Fatalf("expected no error, got %+v", err)
+		}
 	}))
 	defer server.Close()
 

--- a/pkg/meroxa/log_test.go
+++ b/pkg/meroxa/log_test.go
@@ -13,7 +13,9 @@ func TestGetConnectorLogs(t *testing.T) {
 		if want, got := "/v1/connectors/test/logs", req.URL.Path; want != got {
 			t.Fatalf("mismatched of request path: want=%s got=%s", want, got)
 		}
-		w.Write([]byte("[timestamp] log message"))
+		if _, err := w.Write([]byte("[timestamp] log message")); err != nil {
+			t.Fatalf("expected no error, got %+v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -25,6 +27,9 @@ func TestGetConnectorLogs(t *testing.T) {
 	}
 
 	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("expected no error, got %+v", err)
+	}
 	if want, got := "[timestamp] log message", string(b); want != got {
 		t.Fatalf("mismatched of log message: want=%s got=%s", want, got)
 	}
@@ -36,7 +41,9 @@ func TestGetFunctionLogs(t *testing.T) {
 			t.Fatalf("mismatched of request path: want=%s got=%s", want, got)
 		}
 
-		w.Write([]byte("[timestamp] log message"))
+		if _, err := w.Write([]byte("[timestamp] log message")); err != nil {
+			t.Fatalf("expected no error, got %+v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -48,6 +55,9 @@ func TestGetFunctionLogs(t *testing.T) {
 	}
 
 	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("expected no error, got %+v", err)
+	}
 	if want, got := "[timestamp] log message", string(b); want != got {
 		t.Fatalf("mismatched of log message: want=%s got=%s", want, got)
 	}
@@ -59,7 +69,9 @@ func TestGetBuildLogs(t *testing.T) {
 			t.Fatalf("mismatched of request path: want=%s got=%s", want, got)
 		}
 
-		w.Write([]byte("[timestamp] log message"))
+		if _, err := w.Write([]byte("[timestamp] log message")); err != nil {
+			t.Fatalf("expected no error, got %+v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -71,6 +83,9 @@ func TestGetBuildLogs(t *testing.T) {
 	}
 
 	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("expected no error, got %+v", err)
+	}
 	if want, got := "[timestamp] log message", string(b); want != got {
 		t.Fatalf("mismatched of log message: want=%s got=%s", want, got)
 	}

--- a/pkg/meroxa/meroxa.go
+++ b/pkg/meroxa/meroxa.go
@@ -45,7 +45,6 @@ func (e EntityIdentifier) GetNameOrUUID() (string, error) {
 type client struct {
 	baseURL   *url.URL
 	userAgent string
-	token     string
 
 	httpClient *http.Client
 }

--- a/pkg/meroxa/meroxa_test.go
+++ b/pkg/meroxa/meroxa_test.go
@@ -51,6 +51,9 @@ func TestClient_MakeRequest(t *testing.T) {
 		t.Errorf("expected http path %s, got %s", "/api/test", response.Request.URL.Path)
 	}
 	b, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Errorf("expected no error, got %+v", err)
+	}
 	if bytes.Equal(body.Bytes(), b) {
 		t.Errorf("expected http body %s, got %s", body, b)
 	}

--- a/pkg/meroxa/pipeline_test.go
+++ b/pkg/meroxa/pipeline_test.go
@@ -39,8 +39,10 @@ func TestUpdatePipelineStatus(t *testing.T) {
 		}
 
 		// Return response to satisfy client and test response
-		p := generatePipeline(name, newState, nil)
-		json.NewEncoder(w).Encode(p)
+		p := generatePipeline(name, newState)
+		if err := json.NewEncoder(w).Encode(p); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	// Close the server when test finishes
 	defer server.Close()
@@ -59,7 +61,7 @@ func TestUpdatePipelineStatus(t *testing.T) {
 
 func TestUpdatePipeline(t *testing.T) {
 	var pipelineUpdate UpdatePipelineInput
-	var pipeline = generatePipeline("", "", nil)
+	var pipeline = generatePipeline("", "")
 
 	pipelineUpdate.Name = pipeline.Name
 
@@ -80,7 +82,9 @@ func TestUpdatePipeline(t *testing.T) {
 		}
 
 		// Return response to satisfy client and test response
-		json.NewEncoder(w).Encode(pipeline)
+		if err := json.NewEncoder(w).Encode(pipeline); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	// Close the server when test finishes
 	defer server.Close()
@@ -98,7 +102,7 @@ func TestUpdatePipeline(t *testing.T) {
 }
 
 func TestGetPipelines(t *testing.T) {
-	pBase := generatePipeline("without-env", "", nil)
+	pBase := generatePipeline("without-env", "")
 	pWithEnv := generatePipelineWithEnvironment("with-env")
 
 	pipelines := []*Pipeline{&pBase, &pWithEnv}
@@ -168,7 +172,7 @@ func TestCreatePipeline(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if want, got := fmt.Sprintf("%s", pipelinesBasePath), req.URL.Path; want != got {
+		if want, got := pipelinesBasePath, req.URL.Path; want != got {
 			t.Fatalf("mismatched of request path: want=%s got=%s", want, got)
 		}
 
@@ -186,12 +190,14 @@ func TestCreatePipeline(t *testing.T) {
 			t.Errorf("expected same environment")
 		}
 
-		rP := generatePipeline(pi.Name, "", nil)
+		rP := generatePipeline(pi.Name, "")
 		rP.Environment = pi.Environment
 		rP.Environment.UUID = null.StringFrom("067fc522-7f3c-4c71-8749-68f3698c2c68")
 
 		// Return response to satisfy client and test response
-		json.NewEncoder(w).Encode(rP)
+		if err := json.NewEncoder(w).Encode(rP); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	// Close the server when test finishes
 	defer server.Close()
@@ -213,19 +219,13 @@ func TestCreatePipeline(t *testing.T) {
 	}
 }
 
-func generatePipeline(name string, state string, metadata map[string]interface{}) Pipeline {
+func generatePipeline(name string, state string) Pipeline {
 	if name == "" {
 		name = "test"
 	}
 
 	if state == "" {
 		state = "healthy"
-	}
-
-	if metadata == nil {
-		metadata = map[string]interface{}{
-			"custom_metadata": true,
-		}
 	}
 
 	return Pipeline{
@@ -235,7 +235,7 @@ func generatePipeline(name string, state string, metadata map[string]interface{}
 }
 
 func generatePipelineWithEnvironment(name string) Pipeline {
-	p := generatePipeline(name, "", nil)
+	p := generatePipeline(name, "")
 
 	p.Environment = &EntityIdentifier{
 		UUID: null.StringFrom("9c73bbc5-75c2-400d-a270-d8aefe727c15"),

--- a/pkg/meroxa/resource_test.go
+++ b/pkg/meroxa/resource_test.go
@@ -52,7 +52,9 @@ func Test_Resource_PerformActions(t *testing.T) {
 
 				// Return response to satisfy client and test response
 				c := generateResource(resName, "", nil)
-				json.NewEncoder(w).Encode(c)
+				if err := json.NewEncoder(w).Encode(c); err != nil {
+					t.Errorf("expected no error, got %+v", err)
+				}
 			}))
 
 			// Close the server when test finishes
@@ -154,7 +156,7 @@ func TestCreateResource(t *testing.T) {
 			var resource = tc.input()
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				if want, got := fmt.Sprintf("%s", ResourcesBasePath), req.URL.Path; want != got {
+				if want, got := ResourcesBasePath, req.URL.Path; want != got {
 					t.Fatalf("mismatched of request path: want=%s got=%s", want, got)
 				}
 
@@ -189,7 +191,9 @@ func TestCreateResource(t *testing.T) {
 					c.Environment = &EntityIdentifier{Name: resource.Environment.Name}
 				}
 
-				json.NewEncoder(w).Encode(c)
+				if err := json.NewEncoder(w).Encode(c); err != nil {
+					t.Errorf("expected no error, got %+v", err)
+				}
 			}))
 
 			// Close the server when test finishes
@@ -278,7 +282,9 @@ func TestUpdateResource(t *testing.T) {
 			Address:   resource.SSHTunnel.Address,
 			PublicKey: privateKey,
 		}
-		json.NewEncoder(w).Encode(c)
+		if err := json.NewEncoder(w).Encode(c); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 
 	// Close the server when test finishes

--- a/pkg/meroxa/resource_types.go
+++ b/pkg/meroxa/resource_types.go
@@ -3,7 +3,6 @@ package meroxa
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 )
 
@@ -25,7 +24,7 @@ const (
 
 // ListResourceTypes returns the list of supported resources
 func (c *client) ListResourceTypes(ctx context.Context) ([]string, error) {
-	path := fmt.Sprintf("/v1/resource-types")
+	path := "/v1/resource-types"
 
 	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {

--- a/pkg/meroxa/source_test.go
+++ b/pkg/meroxa/source_test.go
@@ -16,7 +16,9 @@ func TestCreateSource(t *testing.T) {
 
 		// Return response to satisfy client and test response
 		s := generateSource(getUrl, putUrl)
-		json.NewEncoder(w).Encode(s)
+		if err := json.NewEncoder(w).Encode(s); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
 	}))
 	// Close the server when test finishes
 	defer server.Close()

--- a/pkg/meroxa/transform.go
+++ b/pkg/meroxa/transform.go
@@ -3,7 +3,6 @@ package meroxa
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 )
 
@@ -25,7 +24,7 @@ type Transform struct {
 
 // ListTransforms returns an array of Transforms (scoped to the calling user)
 func (c *client) ListTransforms(ctx context.Context) ([]*Transform, error) {
-	path := fmt.Sprintf("/v1/transforms")
+	path := "/v1/transforms"
 
 	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {


### PR DESCRIPTION
Removed:
- Private variables that were not in use.
- Parameters that were not in use
- String formatting for a variable that already is a string

Added:
- Error checking for anything that can generate an error
- `nolint` comment when it is convenient and necessary
- Error returns when errors can exist