### PR TITLE
Add Confluent Cloud Resource Type

### DIFF
--- a/pkg/meroxa/resource_types.go
+++ b/pkg/meroxa/resource_types.go
@@ -9,17 +9,18 @@ import (
 type ResourceType string
 
 const (
-	ResourceTypePostgres      ResourceType = "postgres"
-	ResourceTypeMysql         ResourceType = "mysql"
-	ResourceTypeRedshift      ResourceType = "redshift"
-	ResourceTypeUrl           ResourceType = "url"
-	ResourceTypeS3            ResourceType = "s3"
-	ResourceTypeMongodb       ResourceType = "mongodb"
-	ResourceTypeElasticsearch ResourceType = "elasticsearch"
-	ResourceTypeSnowflake     ResourceType = "snowflakedb"
-	ResourceTypeBigquery      ResourceType = "bigquery"
-	ResourceTypeSqlserver     ResourceType = "sqlserver"
-	ResourceTypeCosmosdb      ResourceType = "cosmosdb"
+	ResourceTypePostgres       ResourceType = "postgres"
+	ResourceTypeMysql          ResourceType = "mysql"
+	ResourceTypeRedshift       ResourceType = "redshift"
+	ResourceTypeUrl            ResourceType = "url"
+	ResourceTypeS3             ResourceType = "s3"
+	ResourceTypeMongodb        ResourceType = "mongodb"
+	ResourceTypeElasticsearch  ResourceType = "elasticsearch"
+	ResourceTypeSnowflake      ResourceType = "snowflakedb"
+	ResourceTypeBigquery       ResourceType = "bigquery"
+	ResourceTypeSqlserver      ResourceType = "sqlserver"
+	ResourceTypeCosmosdb       ResourceType = "cosmosdb"
+	ResourceTypeConfluentCloud ResourceType = "confluentcloud"
 )
 
 // ListResourceTypes returns the list of supported resources


### PR DESCRIPTION
Adding `ConfluentCloud` as a resource type to be consumed in [meroxa/cli ](https://github.com/meroxa/cli)

Part of [product#51](https://github.com/meroxa/product/issues/512)