### PR TITLE
Account UUID option

### DIFF
--- a/pkg/meroxa/account.go
+++ b/pkg/meroxa/account.go
@@ -17,7 +17,7 @@ type Account struct {
 
 func (c *client) ListAccounts(ctx context.Context) ([]*Account, error) {
 	path := accountsPath
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -33,8 +33,4 @@ func (c *client) ListAccounts(ctx context.Context) ([]*Account, error) {
 		return nil, err
 	}
 	return accounts, nil
-}
-
-func (c *client) SetClientAccountHeader(accountUUID string) {
-	c.headers[meroxaAccountUUIDHeader] = []string{accountUUID}
 }

--- a/pkg/meroxa/account_test.go
+++ b/pkg/meroxa/account_test.go
@@ -11,15 +11,6 @@ import (
 	"testing"
 )
 
-func TestSetClientActiveAccount(t *testing.T) {
-	client := testClient(nil)
-	client.SetClientAccountHeader("47523a84-3f5b-11ed-b878-0242ac120002")
-	//nolint:staticcheck
-	if client.headers[meroxaAccountUUIDHeader][0] != "47523a84-3f5b-11ed-b878-0242ac120002" {
-		t.Fatal("Meroxa-Account-UUID is not set correctly")
-	}
-}
-
 func TestListAccounts(t *testing.T) {
 	testCases := []struct {
 		desc             string

--- a/pkg/meroxa/application.go
+++ b/pkg/meroxa/application.go
@@ -62,7 +62,7 @@ type ApplicationStatus struct {
 }
 
 func (c *client) CreateApplication(ctx context.Context, input *CreateApplicationInput) (*Application, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodPost, applicationsBasePath, input, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, applicationsBasePath, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func (c *client) CreateApplication(ctx context.Context, input *CreateApplication
 }
 
 func (c *client) CreateApplicationV2(ctx context.Context, input *CreateApplicationInput) (*Application, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodPost, v2applicationsBasePath, input, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, v2applicationsBasePath, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func (c *client) CreateApplicationV2(ctx context.Context, input *CreateApplicati
 }
 
 func (c *client) DeleteApplication(ctx context.Context, name string) error {
-	resp, err := c.MakeRequest(ctx, http.MethodDelete, fmt.Sprintf("%s/%s", applicationsBasePath, name), nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodDelete, fmt.Sprintf("%s/%s", applicationsBasePath, name), nil, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -111,7 +111,7 @@ func (c *client) DeleteApplication(ctx context.Context, name string) error {
 // DeleteApplicationEntities does a bit more than DeleteApplication. Its main purpose is to remove underneath's app resources
 // even in the event the application didn't exist.
 func (c *client) DeleteApplicationEntities(ctx context.Context, name string) (*http.Response, error) {
-	respAppDelete, err := c.MakeRequest(ctx, http.MethodDelete, fmt.Sprintf("%s/%s", applicationsBasePath, name), nil, nil, c.headers)
+	respAppDelete, err := c.MakeRequest(ctx, http.MethodDelete, fmt.Sprintf("%s/%s", applicationsBasePath, name), nil, nil, nil)
 	if err != nil {
 		return respAppDelete, err
 	}
@@ -165,7 +165,7 @@ func (c *client) DeleteApplicationEntities(ctx context.Context, name string) (*h
 }
 
 func (c *client) GetApplication(ctx context.Context, name string) (*Application, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, fmt.Sprintf("%s/%s", applicationsBasePath, name), nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, fmt.Sprintf("%s/%s", applicationsBasePath, name), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (c *client) GetApplication(ctx context.Context, name string) (*Application,
 }
 
 func (c *client) ListApplications(ctx context.Context) ([]*Application, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, applicationsBasePath, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, applicationsBasePath, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/meroxa/build.go
+++ b/pkg/meroxa/build.go
@@ -28,7 +28,7 @@ type Build struct {
 }
 
 func (c *client) GetBuild(ctx context.Context, uuid string) (*Build, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, fmt.Sprintf("%s/%s", buildsBasePath, uuid), nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, fmt.Sprintf("%s/%s", buildsBasePath, uuid), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (c *client) GetBuild(ctx context.Context, uuid string) (*Build, error) {
 }
 
 func (c *client) CreateBuild(ctx context.Context, input *CreateBuildInput) (*Build, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodPost, buildsBasePath, input, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, buildsBasePath, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/meroxa/connector.go
+++ b/pkg/meroxa/connector.go
@@ -80,7 +80,7 @@ func (c *client) CreateConnector(ctx context.Context, input *CreateConnectorInpu
 		input.Configuration = map[string]interface{}{"input": input.Input}
 	}
 	input.Metadata = map[string]interface{}{"mx:connectorType": string(input.Type)}
-	resp, err := c.MakeRequest(ctx, http.MethodPost, connectorsBasePath, input, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, connectorsBasePath, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (c *client) UpdateConnectorStatus(ctx context.Context, nameOrID string, sta
 		State: state,
 	}
 
-	resp, err := c.MakeRequest(ctx, http.MethodPost, path, cr, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, path, cr, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (c *client) UpdateConnectorStatus(ctx context.Context, nameOrID string, sta
 func (c *client) UpdateConnector(ctx context.Context, nameOrID string, input *UpdateConnectorInput) (*Connector, error) {
 	path := fmt.Sprintf("%s/%s", connectorsBasePath, nameOrID)
 
-	resp, err := c.MakeRequest(ctx, http.MethodPatch, path, input, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodPatch, path, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func (c *client) UpdateConnector(ctx context.Context, nameOrID string, input *Up
 func (c *client) ListPipelineConnectors(ctx context.Context, pipelineNameOrID string) ([]*Connector, error) {
 	path := fmt.Sprintf("%s/%s/connectors", pipelinesBasePath, pipelineNameOrID)
 
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func (c *client) ListPipelineConnectors(ctx context.Context, pipelineNameOrID st
 
 // ListConnectors returns an array of Connectors (scoped to the calling user)
 func (c *client) ListConnectors(ctx context.Context) ([]*Connector, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, connectorsBasePath, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, connectorsBasePath, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +200,7 @@ func (c *client) ListConnectors(ctx context.Context) ([]*Connector, error) {
 func (c *client) GetConnectorByNameOrID(ctx context.Context, nameOrID string) (*Connector, error) {
 	path := fmt.Sprintf("%s/%s", connectorsBasePath, nameOrID)
 
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +223,7 @@ func (c *client) GetConnectorByNameOrID(ctx context.Context, nameOrID string) (*
 func (c *client) DeleteConnector(ctx context.Context, nameOrID string) error {
 	path := fmt.Sprintf("%s/%s", connectorsBasePath, nameOrID)
 
-	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/meroxa/connector_test.go
+++ b/pkg/meroxa/connector_test.go
@@ -181,6 +181,7 @@ func TestUpdateConnector(t *testing.T) {
 func testRequester(c *http.Client, u string) *Requester {
 	parsedURL, _ := url.Parse(u)
 	return &Requester{
+		headers:    make(http.Header),
 		baseURL:    parsedURL,
 		httpClient: c,
 	}
@@ -189,7 +190,6 @@ func testRequester(c *http.Client, u string) *Requester {
 func testClient(r requester) *client {
 	return &client{
 		requester: r,
-		headers:   make(http.Header),
 	}
 }
 

--- a/pkg/meroxa/deployment.go
+++ b/pkg/meroxa/deployment.go
@@ -46,7 +46,7 @@ type CreateDeploymentInput struct {
 }
 
 func (c *client) GetLatestDeployment(ctx context.Context, appIdentifier string) (*Deployment, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, fmt.Sprintf("%s/%s/deployments/latest", applicationsBasePath, appIdentifier), nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, fmt.Sprintf("%s/%s/deployments/latest", applicationsBasePath, appIdentifier), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (c *client) CreateDeployment(ctx context.Context, input *CreateDeploymentIn
 		return nil, err
 	}
 
-	resp, err := c.MakeRequest(ctx, http.MethodPost, fmt.Sprintf("%s/%s/deployments", applicationsBasePath, appIdentifier), input, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, fmt.Sprintf("%s/%s/deployments", applicationsBasePath, appIdentifier), input, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/meroxa/endpoint.go
+++ b/pkg/meroxa/endpoint.go
@@ -33,7 +33,7 @@ type Endpoint struct {
 }
 
 func (c *client) CreateEndpoint(ctx context.Context, input *CreateEndpointInput) error {
-	resp, err := c.MakeRequest(ctx, http.MethodPost, endpointBasePath, input, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, endpointBasePath, input, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -43,7 +43,7 @@ func (c *client) CreateEndpoint(ctx context.Context, input *CreateEndpointInput)
 
 func (c *client) GetEndpoint(ctx context.Context, name string) (*Endpoint, error) {
 	path := fmt.Sprintf("%s/%s", endpointBasePath, name)
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func (c *client) GetEndpoint(ctx context.Context, name string) (*Endpoint, error
 
 func (c *client) DeleteEndpoint(ctx context.Context, name string) error {
 	path := fmt.Sprintf("%s/%s", endpointBasePath, name)
-	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -72,7 +72,7 @@ func (c *client) DeleteEndpoint(ctx context.Context, name string) error {
 }
 
 func (c *client) ListEndpoints(ctx context.Context) ([]Endpoint, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, endpointBasePath, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, endpointBasePath, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/meroxa/environment.go
+++ b/pkg/meroxa/environment.go
@@ -141,7 +141,7 @@ type RepairEnvironmentInput struct {
 
 // ListEnvironments returns an array of Environments (scoped to the calling user)
 func (c *client) ListEnvironments(ctx context.Context) ([]*Environment, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, environmentsBasePath, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, environmentsBasePath, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (c *client) ListEnvironments(ctx context.Context) ([]*Environment, error) {
 
 // CreateEnvironment creates a new Environment based on a CreateEnvironmentInput
 func (c *client) CreateEnvironment(ctx context.Context, input *CreateEnvironmentInput) (*Environment, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodPost, environmentsBasePath, input, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, environmentsBasePath, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func (c *client) CreateEnvironment(ctx context.Context, input *CreateEnvironment
 
 func (c *client) GetEnvironment(ctx context.Context, nameOrUUID string) (*Environment, error) {
 	path := fmt.Sprintf("%s/%s", environmentsBasePath, nameOrUUID)
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +204,7 @@ func (c *client) GetEnvironment(ctx context.Context, nameOrUUID string) (*Enviro
 
 func (c *client) DeleteEnvironment(ctx context.Context, nameOrUUID string) (*Environment, error) {
 	path := fmt.Sprintf("%s/%s", environmentsBasePath, nameOrUUID)
-	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +221,7 @@ func (c *client) DeleteEnvironment(ctx context.Context, nameOrUUID string) (*Env
 
 func (c *client) UpdateEnvironment(ctx context.Context, nameOrUUID string, input *UpdateEnvironmentInput) (*Environment, error) {
 	path := fmt.Sprintf("%s/%s", environmentsBasePath, nameOrUUID)
-	resp, err := c.MakeRequest(ctx, http.MethodPatch, path, input, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodPatch, path, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +238,7 @@ func (c *client) UpdateEnvironment(ctx context.Context, nameOrUUID string, input
 
 func (c *client) PerformActionOnEnvironment(ctx context.Context, nameOrUUID string, input *RepairEnvironmentInput) (*Environment, error) {
 	path := fmt.Sprintf("%s/%s/%s", environmentsBasePath, nameOrUUID, "actions")
-	resp, err := c.MakeRequest(ctx, http.MethodPost, path, input, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, path, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/meroxa/function.go
+++ b/pkg/meroxa/function.go
@@ -40,7 +40,7 @@ type CreateFunctionInput struct {
 }
 
 func (c *client) CreateFunction(ctx context.Context, input *CreateFunctionInput) (*Function, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodPost, functionsBasePath, input, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, functionsBasePath, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (c *client) CreateFunction(ctx context.Context, input *CreateFunctionInput)
 func (c *client) GetFunction(ctx context.Context, nameOrUUID string) (*Function, error) {
 	path := fmt.Sprintf("%s/%s", functionsBasePath, nameOrUUID)
 
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func (c *client) GetFunction(ctx context.Context, nameOrUUID string) (*Function,
 }
 
 func (c *client) ListFunctions(ctx context.Context) ([]*Function, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, functionsBasePath, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, functionsBasePath, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (c *client) ListFunctions(ctx context.Context) ([]*Function, error) {
 func (c *client) DeleteFunction(ctx context.Context, nameOrUUID string) (*Function, error) {
 	path := fmt.Sprintf("%s/%s", functionsBasePath, nameOrUUID)
 
-	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/meroxa/log.go
+++ b/pkg/meroxa/log.go
@@ -14,7 +14,7 @@ const (
 
 func (c *client) GetConnectorLogs(ctx context.Context, nameOrID string) (*http.Response, error) {
 	path := fmt.Sprintf("%s/%s/logs", connectorLogsBasePath, nameOrID)
-	headers := c.headers.Clone()
+	headers := make(http.Header)
 	headers["Content-Type"] = []string{textContentType}
 	headers["Accept"] = []string{textContentType}
 	return c.MakeRequest(ctx, http.MethodGet, path, nil, nil, headers)
@@ -22,7 +22,7 @@ func (c *client) GetConnectorLogs(ctx context.Context, nameOrID string) (*http.R
 
 func (c *client) GetFunctionLogs(ctx context.Context, nameOrUUID string) (*http.Response, error) {
 	path := fmt.Sprintf("%s/%s/logs", functionLogsBasePath, nameOrUUID)
-	headers := c.headers.Clone()
+	headers := make(http.Header)
 	headers["Content-Type"] = []string{textContentType}
 	headers["Accept"] = []string{textContentType}
 	return c.MakeRequest(ctx, http.MethodGet, path, nil, nil, headers)
@@ -30,7 +30,7 @@ func (c *client) GetFunctionLogs(ctx context.Context, nameOrUUID string) (*http.
 
 func (c *client) GetBuildLogs(ctx context.Context, uuid string) (*http.Response, error) {
 	path := fmt.Sprintf("%s/%s/logs", buildLogsBasePath, uuid)
-	headers := c.headers.Clone()
+	headers := make(http.Header)
 	headers["Content-Type"] = []string{textContentType}
 	headers["Accept"] = []string{textContentType}
 	return c.MakeRequest(ctx, http.MethodGet, path, nil, nil, headers)

--- a/pkg/meroxa/meroxa.go
+++ b/pkg/meroxa/meroxa.go
@@ -44,12 +44,12 @@ func (e EntityIdentifier) GetNameOrUUID() (string, error) {
 // client represents the Meroxa API Client
 type client struct {
 	requester
-	headers http.Header
 }
 
 type Requester struct {
 	baseURL    *url.URL
 	httpClient *http.Client
+	headers    http.Header
 	userAgent  string
 }
 
@@ -59,7 +59,6 @@ type requester interface {
 
 type account interface {
 	ListAccounts(ctx context.Context) ([]*Account, error)
-	SetClientAccountHeader(accountUUID string)
 }
 
 // Client represents the interface to the Meroxa API
@@ -166,7 +165,6 @@ func New(options ...Option) (Client, error) {
 	}
 	c := &client{
 		requester: r,
-		headers:   make(http.Header),
 	}
 	return c, nil
 }

--- a/pkg/meroxa/options.go
+++ b/pkg/meroxa/options.go
@@ -79,3 +79,14 @@ func WithAuthentication(conf *oauth2.Config, accessToken, refreshToken string, o
 		return nil
 	}
 }
+
+// WithClient sets the http client to use for requests.
+func WithAccountUUID(accountUUID string) Option {
+	return func(r *Requester) error {
+		if r.headers == nil {
+			r.headers = make(http.Header)
+		}
+		r.headers[meroxaAccountUUIDHeader] = []string{accountUUID}
+		return nil
+	}
+}

--- a/pkg/meroxa/pipeline.go
+++ b/pkg/meroxa/pipeline.go
@@ -48,7 +48,7 @@ type UpdatePipelineInput struct {
 
 // CreatePipeline provisions a new Pipeline
 func (c *client) CreatePipeline(ctx context.Context, input *CreatePipelineInput) (*Pipeline, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodPost, pipelinesBasePath, input, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, pipelinesBasePath, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func (c *client) CreatePipeline(ctx context.Context, input *CreatePipelineInput)
 func (c *client) UpdatePipeline(ctx context.Context, pipelineNameOrID string, input *UpdatePipelineInput) (*Pipeline, error) {
 	path := fmt.Sprintf("%s/%s", pipelinesBasePath, pipelineNameOrID)
 
-	resp, err := c.MakeRequest(ctx, http.MethodPatch, path, input, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodPatch, path, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (c *client) UpdatePipelineStatus(ctx context.Context, pipelineNameOrID stri
 		State: action,
 	}
 
-	resp, err := c.MakeRequest(ctx, http.MethodPost, path, cr, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, path, cr, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (c *client) UpdatePipelineStatus(ctx context.Context, pipelineNameOrID stri
 
 // ListPipelines returns an array of Pipelines (scoped to the calling user)
 func (c *client) ListPipelines(ctx context.Context) ([]*Pipeline, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, pipelinesBasePath, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, pipelinesBasePath, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +147,7 @@ func (c *client) GetPipelineByName(ctx context.Context, name string) (*Pipeline,
 		"name": {name},
 	}
 
-	resp, err := c.MakeRequest(ctx, http.MethodGet, pipelinesBasePath, nil, params, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, pipelinesBasePath, nil, params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (c *client) GetPipelineByName(ctx context.Context, name string) (*Pipeline,
 // GetPipeline returns a Pipeline with the given id
 func (c *client) GetPipeline(ctx context.Context, pipelineID int) (*Pipeline, error) {
 	path := fmt.Sprintf("%s/%d", pipelinesBasePath, pipelineID)
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +192,7 @@ func (c *client) GetPipeline(ctx context.Context, pipelineID int) (*Pipeline, er
 func (c *client) DeletePipeline(ctx context.Context, nameOrID string) error {
 	path := fmt.Sprintf("%s/%s", pipelinesBasePath, nameOrID)
 
-	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/meroxa/resource.go
+++ b/pkg/meroxa/resource.go
@@ -95,7 +95,7 @@ func (c *client) CreateResource(ctx context.Context, input *CreateResourceInput)
 		return nil, err
 	}
 
-	resp, err := c.MakeRequest(ctx, http.MethodPost, ResourcesBasePath, input, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, ResourcesBasePath, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func (c *client) UpdateResource(ctx context.Context, nameOrID string, input *Upd
 		}
 	}
 
-	resp, err := c.MakeRequest(ctx, http.MethodPatch, fmt.Sprintf("%s/%s", ResourcesBasePath, nameOrID), input, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodPatch, fmt.Sprintf("%s/%s", ResourcesBasePath, nameOrID), input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func (c *client) performResourceAction(ctx context.Context, nameOrID string, act
 		Action: action,
 	}
 
-	resp, err := c.MakeRequest(ctx, http.MethodPost, path, body, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, path, body, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (c *client) performResourceAction(ctx context.Context, nameOrID string, act
 
 // ListResources returns an array of Resources (scoped to the calling user)
 func (c *client) ListResources(ctx context.Context) ([]*Resource, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, ResourcesBasePath, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, ResourcesBasePath, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +205,7 @@ func (c *client) ListResources(ctx context.Context) ([]*Resource, error) {
 func (c *client) GetResourceByNameOrID(ctx context.Context, nameOrID string) (*Resource, error) {
 	path := fmt.Sprintf("%s/%s", ResourcesBasePath, nameOrID)
 
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func (c *client) GetResourceByNameOrID(ctx context.Context, nameOrID string) (*R
 func (c *client) DeleteResource(ctx context.Context, nameOrID string) error {
 	path := fmt.Sprintf("%s/%s", ResourcesBasePath, nameOrID)
 
-	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/meroxa/resource_types.go
+++ b/pkg/meroxa/resource_types.go
@@ -28,7 +28,7 @@ const (
 func (c *client) ListResourceTypes(ctx context.Context) ([]string, error) {
 	path := "/v1/resource-types"
 
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/meroxa/source.go
+++ b/pkg/meroxa/source.go
@@ -18,7 +18,7 @@ type SourceBlob struct {
 }
 
 func (c *client) CreateSource(ctx context.Context) (*Source, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodPost, sourcesBasePath, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, sourcesBasePath, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/meroxa/transform.go
+++ b/pkg/meroxa/transform.go
@@ -26,7 +26,7 @@ type Transform struct {
 func (c *client) ListTransforms(ctx context.Context) ([]*Transform, error) {
 	path := "/v1/transforms"
 
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/meroxa/user.go
+++ b/pkg/meroxa/user.go
@@ -25,7 +25,7 @@ type User struct {
 func (c *client) GetUser(ctx context.Context) (*User, error) {
 	path := fmt.Sprintf("%s/me", usersPath)
 
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, c.headers)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mock/mock_client.go
+++ b/pkg/mock/mock_client.go
@@ -90,18 +90,6 @@ func (mr *MockaccountMockRecorder) ListAccounts(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccounts", reflect.TypeOf((*Mockaccount)(nil).ListAccounts), ctx)
 }
 
-// SetClientAccountHeader mocks base method.
-func (m *Mockaccount) SetClientAccountHeader(accountUUID string) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetClientAccountHeader", accountUUID)
-}
-
-// SetClientAccountHeader indicates an expected call of SetClientAccountHeader.
-func (mr *MockaccountMockRecorder) SetClientAccountHeader(accountUUID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetClientAccountHeader", reflect.TypeOf((*Mockaccount)(nil).SetClientAccountHeader), accountUUID)
-}
-
 // MockClient is a mock of Client interface.
 type MockClient struct {
 	ctrl     *gomock.Controller
@@ -837,18 +825,6 @@ func (m *MockClient) RotateTunnelKeyForResource(ctx context.Context, nameOrID st
 func (mr *MockClientMockRecorder) RotateTunnelKeyForResource(ctx, nameOrID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RotateTunnelKeyForResource", reflect.TypeOf((*MockClient)(nil).RotateTunnelKeyForResource), ctx, nameOrID)
-}
-
-// SetClientAccountHeader mocks base method.
-func (m *MockClient) SetClientAccountHeader(accountUUID string) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetClientAccountHeader", accountUUID)
-}
-
-// SetClientAccountHeader indicates an expected call of SetClientAccountHeader.
-func (mr *MockClientMockRecorder) SetClientAccountHeader(accountUUID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetClientAccountHeader", reflect.TypeOf((*MockClient)(nil).SetClientAccountHeader), accountUUID)
 }
 
 // UpdateConnector mocks base method.


### PR DESCRIPTION
Instead of passing the headers individually, using a `WithAccountUUID` option.