### PR TITLE
Refactor error message so that type is not interpreted as a problem

### DIFF
--- a/pkg/meroxa/api_errors.go
+++ b/pkg/meroxa/api_errors.go
@@ -18,14 +18,14 @@ func (err *errResponse) Error() string {
 	msg := err.Message
 
 	if errCount := len(err.Details); errCount > 0 {
-		msg = fmt.Sprintf("%s. %d %s occurred:%s",
+		msg = fmt.Sprintf("%s. %d %s reported:%s",
 			msg,
 			errCount,
 			func() string {
 				if errCount > 1 {
-					return "problems"
+					return "details"
 				}
-				return "problem"
+				return "detail"
 			}(),
 			mapToString(err.Details),
 		)

--- a/pkg/meroxa/api_errors_test.go
+++ b/pkg/meroxa/api_errors_test.go
@@ -64,7 +64,7 @@ func TestHandleAPIErrors(t *testing.T) {
 					"type": {"invalid"},
 				},
 			},
-			"resource with name test already exists. 2 problems occurred:\n1. name: \"too long\", \"invalid\"\n2. type: \"invalid\"",
+			"resource with name test already exists. 2 details reported:\n1. name: \"too long\", \"invalid\"\n2. type: \"invalid\"",
 		},
 		{http422JSONResponse(errorJSONResponse(`{ "code": "already_exists", "message": "resource with name test already exists", "details": { "type": ["invalid"] }}`)),
 			&errResponse{
@@ -74,7 +74,7 @@ func TestHandleAPIErrors(t *testing.T) {
 					"type": {"invalid"},
 				},
 			},
-			"resource with name test already exists. 1 problem occurred:\n1. type: \"invalid\"",
+			"resource with name test already exists. 1 detail reported:\n1. type: \"invalid\"",
 		},
 	}
 


### PR DESCRIPTION
Error: failed to create or update resource. 1 problem occurred: 1. type: "postgres"

this feels a bit confusing to me. I prefer this

Error: failed to create or update resource. 1 detail reported: 1. type: "postgres"