### PR TITLE
Add environment information on builds

### DIFF
--- a/pkg/meroxa/build.go
+++ b/pkg/meroxa/build.go
@@ -10,7 +10,8 @@ import (
 const buildsBasePath = "/v1/builds"
 
 type CreateBuildInput struct {
-	SourceBlob SourceBlob `json:"source_blob"`
+	SourceBlob  SourceBlob        `json:"source_blob"`
+	Environment *EntityIdentifier `json:"environment,omitempty"`
 }
 
 type BuildStatus struct {
@@ -19,12 +20,13 @@ type BuildStatus struct {
 }
 
 type Build struct {
-	Uuid       string      `json:"uuid"`
-	Status     BuildStatus `json:"status"`
-	CreatedAt  string      `json:"created_at"`
-	UpdatedAt  string      `json:"updated_at"`
-	SourceBlob SourceBlob  `json:"source_blob"`
-	Image      string      `json:"image"`
+	Uuid        string            `json:"uuid"`
+	Status      BuildStatus       `json:"status"`
+	CreatedAt   string            `json:"created_at"`
+	UpdatedAt   string            `json:"updated_at"`
+	SourceBlob  SourceBlob        `json:"source_blob"`
+	Image       string            `json:"image"`
+	Environment *EntityIdentifier `json:"environment,omitempty"`
 }
 
 func (c *client) GetBuild(ctx context.Context, uuid string) (*Build, error) {

--- a/pkg/meroxa/build_test.go
+++ b/pkg/meroxa/build_test.go
@@ -57,6 +57,62 @@ func TestCreateBuild(t *testing.T) {
 	}
 }
 
+func TestCreateBuildV2(t *testing.T) {
+	input := CreateBuildInput{
+		SourceBlob: SourceBlob{
+			Url: "https://meroxa-test.url",
+		},
+		Environment: &EntityIdentifier{UUID: "123456"},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// Test request
+		type connectionRequest struct {
+			SourceBlob  SourceBlob        `json:"source_blob"`
+			Environment *EntityIdentifier `json:"environment,omitempty"`
+		}
+
+		var cr connectionRequest
+		err := json.NewDecoder(req.Body).Decode(&cr)
+		if err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
+
+		if cr.SourceBlob.Url != input.SourceBlob.Url {
+			t.Errorf("expected url %s, got %s", input.SourceBlob.Url, cr.SourceBlob.Url)
+		}
+
+		if cr.Environment.UUID != input.Environment.UUID {
+			t.Errorf("expected environment %s, got %s", input.Environment.UUID, cr.Environment.UUID)
+		}
+
+		defer req.Body.Close()
+
+		// Return response to satisfy client and test response
+		b := generateBuildV2("", input.SourceBlob.Url, input.Environment.UUID)
+		if err := json.NewEncoder(w).Encode(b); err != nil {
+			t.Errorf("expected no error, got %+v", err)
+		}
+	}))
+	// Close the server when test finishes
+	defer server.Close()
+
+	c := testClient(testRequester(server.Client(), server.URL))
+
+	resp, err := c.CreateBuild(context.Background(), &input)
+
+	if err != nil {
+		t.Errorf("expected no error, got %+v", err)
+	}
+
+	if resp.SourceBlob.Url != input.SourceBlob.Url {
+		t.Errorf("expected name %s, got %s", input.SourceBlob.Url, resp.SourceBlob.Url)
+	}
+	if resp.Environment == nil {
+		t.Errorf("expected environment %s, got %s", input.Environment.UUID, resp.Environment.UUID)
+	}
+}
+
 func TestGetBuild(t *testing.T) {
 	uuid := "31152ef2-16e0-4c8e-8bd1-9e2181c4974a"
 	build := generateBuild(uuid, "")
@@ -97,4 +153,18 @@ func generateBuild(uuid, url string) Build {
 		url = "https://meroxa-test.url"
 	}
 	return Build{Uuid: uuid, SourceBlob: SourceBlob{Url: url}}
+}
+
+func generateBuildV2(uuid, url, env string) Build {
+	if uuid == "" {
+		uuid = "31152ef2-16e0-4c8e-8bd1-9e2181c4974a"
+	}
+
+	if url == "" {
+		url = "https://meroxa-test.url"
+	}
+	if env == "" {
+		env = "...."
+	}
+	return Build{Uuid: uuid, SourceBlob: SourceBlob{Url: url}, Environment: &EntityIdentifier{UUID: env}}
 }

--- a/pkg/meroxa/build_test.go
+++ b/pkg/meroxa/build_test.go
@@ -57,7 +57,7 @@ func TestCreateBuild(t *testing.T) {
 	}
 }
 
-func TestCreateBuildV2(t *testing.T) {
+func TestCreateBuildWithEnv(t *testing.T) {
 	input := CreateBuildInput{
 		SourceBlob: SourceBlob{
 			Url: "https://meroxa-test.url",
@@ -89,7 +89,7 @@ func TestCreateBuildV2(t *testing.T) {
 		defer req.Body.Close()
 
 		// Return response to satisfy client and test response
-		b := generateBuildV2("", input.SourceBlob.Url, input.Environment.UUID)
+		b := generateBuildWithEnv("", input.SourceBlob.Url, input.Environment.UUID)
 		if err := json.NewEncoder(w).Encode(b); err != nil {
 			t.Errorf("expected no error, got %+v", err)
 		}
@@ -155,7 +155,7 @@ func generateBuild(uuid, url string) Build {
 	return Build{Uuid: uuid, SourceBlob: SourceBlob{Url: url}}
 }
 
-func generateBuildV2(uuid, url, env string) Build {
+func generateBuildWithEnv(uuid, url, env string) Build {
 	if uuid == "" {
 		uuid = "31152ef2-16e0-4c8e-8bd1-9e2181c4974a"
 	}


### PR DESCRIPTION
## Description of change

Adding environment information on builds as part of enabling functions on apps in envs. 

Fixes [<GitHub Issue>](https://github.com/meroxa/meroxa-go/issues/166)

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube
